### PR TITLE
Using latest RC2 bits from NuGet

### DIFF
--- a/src/lightinject_issue/Startup.cs
+++ b/src/lightinject_issue/Startup.cs
@@ -12,8 +12,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Tokens;
-using Newtonsoft.Json;
 
 namespace lightinject_issue
 {

--- a/src/lightinject_issue/project.json
+++ b/src/lightinject_issue/project.json
@@ -6,11 +6,11 @@
     },
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
-    "LightInject.Microsoft.DependencyInjection": "1.0.1-*",
+    "LightInject.Microsoft.DependencyInjection": "1.0.1-rc2-2",
     "LightInject": "4.0.10-rc2-2",
     "Microsoft.EntityFrameworkCore.InMemory": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final",
-    "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0-rc3-21052",
+    "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-final"
   },


### PR DESCRIPTION
Try to avoid pulling from MyGet. Use NuGet as your only source for packages. asp.net and .net core are about to RTM any day now. Until then use the latest RC2 stuff from NuGet.
